### PR TITLE
fix: Save indicator position

### DIFF
--- a/sample/src/main/java/com/liangfeizc/rubberindicator/MainActivity.java
+++ b/sample/src/main/java/com/liangfeizc/rubberindicator/MainActivity.java
@@ -22,6 +22,10 @@ public class MainActivity extends AppCompatActivity
     private static final int SWIPE_THRESHOLD_VELOCITY = 200;
     
     private static final String KEY_INDICATOR_POSITION = "indicator_position";
+    private static final String KEY_INDICATOR_ITEM_NUM = "indicator_item_num";
+
+    // set the number of indicator items to 5
+    private int indicatorItemNum = 5;
 
     private TextView mTextView;
     private RubberIndicator mRubberIndicator;
@@ -40,9 +44,9 @@ public class MainActivity extends AppCompatActivity
         
         // check to see if savedInstanceState is null
         if (savedInstanceState != null) {
-            mRubberIndicator.setCount(5, savedInstanceState.getInt(KEY_INDICATOR_POSITION));
+            mRubberIndicator.setCount(savedInstanceState.getInt(KEY_INDICATOR_ITEM_NUM), savedInstanceState.getInt(KEY_INDICATOR_POSITION));
         } else {
-            mRubberIndicator.setCount(5, 2);
+            mRubberIndicator.setCount(indicatorItemNum, 2);
         }
         
         //mRubberIndicator.setCount(5, 2);
@@ -53,6 +57,7 @@ public class MainActivity extends AppCompatActivity
     @Override
     protected void onSaveInstanceState(Bundle outState) {
         outState.putInt(KEY_INDICATOR_POSITION, mRubberIndicator.getFocusPosition());
+        outState.putInt(KEY_INDICATOR_ITEM_NUM, mRubberIndicator.getChildCount());
         super.onSaveInstanceState(outState);
     }
 

--- a/sample/src/main/java/com/liangfeizc/rubberindicator/MainActivity.java
+++ b/sample/src/main/java/com/liangfeizc/rubberindicator/MainActivity.java
@@ -20,6 +20,8 @@ public class MainActivity extends AppCompatActivity
     private static final int SWIPE_MIN_DISTANCE = 120;
     private static final int SWIPE_MAX_OFF_PATH = 250;
     private static final int SWIPE_THRESHOLD_VELOCITY = 200;
+    
+    private static final String KEY_INDICATOR_POSITION = "indicator_position";
 
     private TextView mTextView;
     private RubberIndicator mRubberIndicator;
@@ -35,9 +37,23 @@ public class MainActivity extends AppCompatActivity
 
         mRubberIndicator = (RubberIndicator) findViewById(R.id.rubber);
         mTextView = (TextView) findViewById(R.id.focus_position);
-        mRubberIndicator.setCount(5, 2);
+        
+        // check to see if savedInstanceState is null
+        if (savedInstanceState != null) {
+            mRubberIndicator.setCount(5, savedInstanceState.getInt(KEY_INDICATOR_POSITION));
+        } else {
+            mRubberIndicator.setCount(5, 2);
+        }
+        
+        //mRubberIndicator.setCount(5, 2);
         mRubberIndicator.setOnMoveListener(this);
         updateFocusPosition();
+    }
+    
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        outState.putInt(KEY_INDICATOR_POSITION, mRubberIndicator.getFocusPosition());
+        super.onSaveInstanceState(outState);
     }
 
     @Override


### PR DESCRIPTION
We save the indicator position so that when device orientation changes, the position can be properly restored.
